### PR TITLE
feat: use template for egi acknowledgement

### DIFF
--- a/proj/pred/templates/pred/egi_acknowledgement.html
+++ b/proj/pred/templates/pred/egi_acknowledgement.html
@@ -1,0 +1,7 @@
+<p>
+    This work used the 
+<a href="https://www.egi.eu/infrastructure/cloud/">
+    EGI infrastructure
+</a>
+    with the support of IN2P3-IRES, INFN-CLOUD-BARI and TR-FC1-ULAKBIM.
+</p>

--- a/proj/pred/templates/pred/help.html
+++ b/proj/pred/templates/pred/help.html
@@ -42,11 +42,7 @@
             href="http://topcons.net">TOPCONS</a>, which
             predict also the signal peptide.
             </p>
-
-            <p>This work used the <a href="https://www.egi.eu/infrastructure/cloud/">EGI infrastructure</a>
-￼              with the support of IN2P3-IRES, INFN-CLOUD-BARI and TR-FC1-ULAKBIM.
-￼            </p>
-
+            {% include "pred/egi_acknowledgement.html" %}
         </td> </tr>
       </table>
 

--- a/proj/pred/templates/pred/submit_seq.html
+++ b/proj/pred/templates/pred/submit_seq.html
@@ -82,9 +82,7 @@ document.getElementById('options').style.display = 'none';
      </td></tr>
      <tr><td>
          <h3>Resource provider</h3>
-         <p>This work used the <a href="https://www.egi.eu/infrastructure/cloud/">EGI infrastructure</a>
-￼              with the support of IN2P3-IRES, INFN-CLOUD-BARI and TR-FC1-ULAKBIM.
-￼            </p>
+         {% include "pred/egi_acknowledgement.html" %}
      </td></tr>
  </table>
 


### PR DESCRIPTION
This PR solved the unwanted `obj` symbol in the acknowledgement text (see [this comment](https://github.com/NBISweden/predictprotein-webserver-scampi2/pull/24#pullrequestreview-876172070) and use a template html file for the acknowledgements so that the text is not duplicated. 

